### PR TITLE
add async generators functions to subscribe to updates

### DIFF
--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -226,7 +226,7 @@ export class SearcherClient {
     });
   }
 
-  // Yields on updates to the provided accounts.
+  // Yields on bundle results.
   async *bundleResults(
     onError: (e: Error) => void
   ): AsyncGenerator<BundleResult> {


### PR DESCRIPTION
having to rely on callbacks can be a pita and is not considered good practice.
- added `programUpdates`, `accountUpdates` and `bundleResults` functions that follow the async generator pattern